### PR TITLE
set web dir parameter on extension

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -17,6 +17,9 @@ checks:
         line_length:
             max_length: '120'
         function_in_camel_caps: true
+        excluded_dependencies:
+            - myclabs/deep-copy
+            - symfony/symfony
 
 filter: {  }
 coding_style:

--- a/DependencyInjection/IulyanpElixirMixExtension.php
+++ b/DependencyInjection/IulyanpElixirMixExtension.php
@@ -22,6 +22,8 @@ class IulyanpElixirMixExtension extends Extension
         $configuration = new Configuration();
         $config = $this->processConfiguration($configuration, $configs);
 
+        $container->setParameter('web_dir', $config['web_dir']);
+
         $loader = new Loader\YamlFileLoader($container, new FileLocator(__DIR__ . '/../Resources/config'));
         $loader->load('services.yml');
     }

--- a/Tests/DependencyInjection/IulyanpElixirMixExtensionTest.php
+++ b/Tests/DependencyInjection/IulyanpElixirMixExtensionTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Iulyanp\ElixirMixBundle\Tests\DependencyInjection;
+
+use Iulyanp\ElixirMixBundle\DependencyInjection\IulyanpElixirMixExtension;
+use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionTestCase;
+
+class IulyanpElixirMixExtensionTest extends AbstractExtensionTestCase
+{
+    protected function getContainerExtensions()
+    {
+        return [
+            new IulyanpElixirMixExtension(),
+        ];
+    }
+
+    public function testConfiguration()
+    {
+        $config = [
+            'web_dir' => '/path/to/manifest.json',
+        ];
+
+        $this->load($config);
+
+        $this->assertContainerBuilderHasParameter('web_dir', '/path/to/manifest.json');
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
     "symfony/symfony": ">=2.7"
   },
   "require-dev": {
-    "phpunit/phpunit": "^5.5"
+    "phpunit/phpunit": "^5.5",
+    "matthiasnoback/symfony-dependency-injection-test": "^1.2.0"
   },
   "extra": {
     "branch-alias": {


### PR DESCRIPTION
When the bundle is installed you need to create the parameter web_dir in your project. But it is not necessary because you have added it on the configuration.

So, the easy solution is to create that parameter on the extension.